### PR TITLE
Give LotRPlayerColony a Backstory Category to get rid of annoying error.

### DIFF
--- a/Defs/LotR_Scenario.xml
+++ b/Defs/LotR_Scenario.xml
@@ -11,6 +11,9 @@
     <pawnSingular>villager</pawnSingular>
     <pawnsPlural>villagers</pawnsPlural>
     <techLevel>Medieval</techLevel>
+	<backstoryCategories>
+      <li>Civil</li>
+    </backstoryCategories>
     <expandingIconTexture>World/WorldObjects/Expanding/Town</expandingIconTexture>
     <playerInitialSettlementNameMaker>NamerInitialSettlementColony</playerInitialSettlementNameMaker>
     <factionNameMaker>NamerFactionOutlander</factionNameMaker>

--- a/Defs/LotR_Scenario.xml
+++ b/Defs/LotR_Scenario.xml
@@ -11,7 +11,7 @@
     <pawnSingular>villager</pawnSingular>
     <pawnsPlural>villagers</pawnsPlural>
     <techLevel>Medieval</techLevel>
-	<backstoryCategories>
+    <backstoryCategories>
       <li>Civil</li>
     </backstoryCategories>
     <expandingIconTexture>World/WorldObjects/Expanding/Town</expandingIconTexture>


### PR DESCRIPTION
Used to get an annoying error every time the game was loaded with LotRims, this gets rid of it!
This the same backstory the New Arrivals colony has in the Core scenarios.